### PR TITLE
Use PropTypes from prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "peerDependencies": {
     "react": "^15.4.1"
   },
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",

--- a/src/Visit.js
+++ b/src/Visit.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 export default class Visit extends Component {
 
@@ -10,10 +11,10 @@ export default class Visit extends Component {
 
    static get propTypes () {
      return {
-       containerElement: React.PropTypes.object,
-       onVisit: React.PropTypes.func,
-       onLeave: React.PropTypes.func,
-       visitStyle: React.PropTypes.object
+       containerElement: PropTypes.object,
+       onVisit: PropTypes.func,
+       onLeave: PropTypes.func,
+       visitStyle: PropTypes.object
      }
    }
 


### PR DESCRIPTION
Use `prop-types` package instead of `React.PropTypes` which is deprecated.